### PR TITLE
feat: プロジェクト作成機能を追加

### DIFF
--- a/apps/hono-api/drizzle/0003_tired_randall_flagg.sql
+++ b/apps/hono-api/drizzle/0003_tired_randall_flagg.sql
@@ -1,0 +1,17 @@
+CREATE TABLE `project_members` (
+	`id` text PRIMARY KEY NOT NULL,
+	`project_id` text NOT NULL,
+	`user_id` text NOT NULL,
+	`created_at` integer NOT NULL,
+	FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE TABLE `projects` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text(255) NOT NULL,
+	`created_by` text NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	FOREIGN KEY (`created_by`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE no action
+);

--- a/apps/hono-api/drizzle/meta/0003_snapshot.json
+++ b/apps/hono-api/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,289 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "6e41aba0-03ac-4eef-b6df-996904f4d744",
+  "prevId": "afe715c5-ec02-49c0-9cf1-3be4d6649578",
+  "tables": {
+    "project_members": {
+      "name": "project_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_members_project_id_projects_id_fk": {
+          "name": "project_members_project_id_projects_id_fk",
+          "tableFrom": "project_members",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "project_members_user_id_users_id_fk": {
+          "name": "project_members_user_id_users_id_fk",
+          "tableFrom": "project_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "projects_created_by_users_id_fk": {
+          "name": "projects_created_by_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tasks": {
+      "name": "tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tasks_created_by_users_id_fk": {
+          "name": "tasks_created_by_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tasks_updated_by_users_id_fk": {
+          "name": "tasks_updated_by_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/hono-api/drizzle/meta/_journal.json
+++ b/apps/hono-api/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1751196823651,
       "tag": "0002_brave_barracuda",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1751642419692,
+      "tag": "0003_tired_randall_flagg",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/hono-api/src/application/service/projects.ts
+++ b/apps/hono-api/src/application/service/projects.ts
@@ -1,0 +1,15 @@
+import type { IProjectsRepository } from "../../domain/interface/projects-repository.js";
+import { Project } from "../../domain/project.js";
+
+type Dependencies = {
+  projectsRepository: IProjectsRepository;
+};
+
+export const createProject = async (
+  deps: Dependencies,
+  name: string,
+  createdBy: string,
+) => {
+  const project = Project.create(name, createdBy);
+  return deps.projectsRepository.create(project);
+};

--- a/apps/hono-api/src/domain/interface/projects-repository.ts
+++ b/apps/hono-api/src/domain/interface/projects-repository.ts
@@ -1,0 +1,7 @@
+import type { Project } from "../project.js";
+
+export interface IProjectsRepository {
+  create(project: Project): Promise<Project>;
+  findById(id: string): Promise<Project | null>;
+  findByUserId(userId: string): Promise<Project[]>;
+}

--- a/apps/hono-api/src/domain/project.ts
+++ b/apps/hono-api/src/domain/project.ts
@@ -1,0 +1,29 @@
+import { nanoid } from "nanoid";
+
+export class Project {
+  constructor(
+    private readonly _id: string,
+    private readonly _name: string,
+    private readonly _createdBy: string,
+  ) {}
+
+  static create(name: string, createdBy: string): Project {
+    return new Project(nanoid(), name, createdBy);
+  }
+
+  static restore(id: string, name: string, createdBy: string): Project {
+    return new Project(id, name, createdBy);
+  }
+
+  get id(): string {
+    return this._id;
+  }
+
+  get name(): string {
+    return this._name;
+  }
+
+  get createdBy(): string {
+    return this._createdBy;
+  }
+}

--- a/apps/hono-api/src/domain/value/role.ts
+++ b/apps/hono-api/src/domain/value/role.ts
@@ -67,4 +67,11 @@ export class UserRole {
   isAdmin(): boolean {
     return this._value === UserRoleConstants.ADMIN;
   }
+
+  static isAdminRole(roleValue: string | number): boolean {
+    if (typeof roleValue === "number") {
+      return roleValue === UserRoleDbValues.ADMIN;
+    }
+    return roleValue === UserRoleConstants.ADMIN;
+  }
 }

--- a/apps/hono-api/src/infrastructure/auth/middleware.ts
+++ b/apps/hono-api/src/infrastructure/auth/middleware.ts
@@ -51,3 +51,23 @@ export const optionalAuthMiddleware: MiddlewareHandler<Context> = async (
 
   await next();
 };
+
+export const adminMiddleware: MiddlewareHandler<Context> = async (
+  c,
+  next,
+): Promise<Response | void> => {
+  const logger = c.get("logger");
+  const user = c.get("user");
+
+  if (!user) {
+    logger.warn("No user context found");
+    return c.json({ errors: ["Authentication required"] }, 401);
+  }
+
+  if (user.role !== "2") {
+    logger.warn({ userId: user.userId, role: user.role }, "Admin access required");
+    return c.json({ errors: ["Admin access required"] }, 403);
+  }
+
+  await next();
+};

--- a/apps/hono-api/src/infrastructure/auth/middleware.ts
+++ b/apps/hono-api/src/infrastructure/auth/middleware.ts
@@ -1,6 +1,7 @@
 import type { MiddlewareHandler } from "hono";
 import { getCookie } from "hono/cookie";
 
+import { UserRole } from "../../domain/value/role.js";
 import type { Context } from "../context.js";
 
 import { verifyAccessToken } from "./jwt.js";
@@ -64,7 +65,7 @@ export const adminMiddleware: MiddlewareHandler<Context> = async (
     return c.json({ errors: ["Authentication required"] }, 401);
   }
 
-  if (user.role !== "2") {
+  if (!UserRole.isAdminRole(user.role)) {
     logger.warn({ userId: user.userId, role: user.role }, "Admin access required");
     return c.json({ errors: ["Admin access required"] }, 403);
   }

--- a/apps/hono-api/src/infrastructure/context.ts
+++ b/apps/hono-api/src/infrastructure/context.ts
@@ -1,3 +1,4 @@
+import type { IProjectsRepository } from "../domain/interface/projects-repository.js";
 import type { ITasksRepository } from "../domain/interface/tasks-repository.js";
 import type { IUsersRepository } from "../domain/interface/users-repository.js";
 
@@ -13,6 +14,7 @@ export type Context = {
   Variables: {
     tasksRepository: ITasksRepository;
     usersRepository: IUsersRepository;
+    projectsRepository: IProjectsRepository;
     logger: Logger;
     traceId: string;
     user?: AuthenticatedUser;

--- a/apps/hono-api/src/infrastructure/database/schema.ts
+++ b/apps/hono-api/src/infrastructure/database/schema.ts
@@ -14,6 +14,33 @@ export const users = sqliteTable("users", {
     .$defaultFn(() => new Date()),
 });
 
+export const projects = sqliteTable("projects", {
+  id: text("id").primaryKey(),
+  name: text("name", { length: 255 }).notNull(),
+  createdBy: text("created_by")
+    .notNull()
+    .references(() => users.id),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+  updatedAt: integer("updated_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+});
+
+export const projectMembers = sqliteTable("project_members", {
+  id: text("id").primaryKey(),
+  projectId: text("project_id")
+    .notNull()
+    .references(() => projects.id),
+  userId: text("user_id")
+    .notNull()
+    .references(() => users.id),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+});
+
 export const tasks = sqliteTable("tasks", {
   id: text("id").primaryKey(),
   name: text("name", { length: 255 }).notNull(),

--- a/apps/hono-api/src/infrastructure/repository/projects-repository.ts
+++ b/apps/hono-api/src/infrastructure/repository/projects-repository.ts
@@ -1,0 +1,48 @@
+import { eq } from "drizzle-orm";
+import { nanoid } from "nanoid";
+import type { IProjectsRepository } from "../../domain/interface/projects-repository.js";
+import { Project } from "../../domain/project.js";
+import { db } from "../database/connection.js";
+import { projectMembers, projects } from "../database/schema.js";
+
+export class ProjectsRepository implements IProjectsRepository {
+  async create(project: Project): Promise<Project> {
+    await db.transaction(async (tx) => {
+      await tx.insert(projects).values({
+        id: project.id,
+        name: project.name,
+        createdBy: project.createdBy,
+      });
+
+      await tx.insert(projectMembers).values({
+        id: nanoid(),
+        projectId: project.id,
+        userId: project.createdBy,
+      });
+    });
+
+    return project;
+  }
+
+  async findById(id: string): Promise<Project | null> {
+    const rows = await db.select().from(projects).where(eq(projects.id, id));
+    if (rows.length === 0) return null;
+
+    const row = rows[0]!;
+    return Project.restore(row.id, row.name, row.createdBy);
+  }
+
+  async findByUserId(userId: string): Promise<Project[]> {
+    const rows = await db
+      .select({
+        id: projects.id,
+        name: projects.name,
+        createdBy: projects.createdBy,
+      })
+      .from(projects)
+      .innerJoin(projectMembers, eq(projects.id, projectMembers.projectId))
+      .where(eq(projectMembers.userId, userId));
+
+    return rows.map((row) => Project.restore(row.id, row.name, row.createdBy));
+  }
+}

--- a/apps/hono-api/src/infrastructure/routes/projects.ts
+++ b/apps/hono-api/src/infrastructure/routes/projects.ts
@@ -1,0 +1,46 @@
+import { OpenAPIHono } from "@hono/zod-openapi";
+
+import { createProject } from "../../application/service/projects.js";
+import { adminMiddleware, authMiddleware } from "../auth/middleware.js";
+import type { Context } from "../context.js";
+import { createProjectRoute } from "../schemas/projects.js";
+
+const app = new OpenAPIHono<Context>();
+
+app.use("*", authMiddleware);
+
+app.use(createProjectRoute.getRoutingPath(), adminMiddleware);
+
+app.openapi(createProjectRoute, async (c) => {
+  const logger = c.get("logger");
+  const user = c.get("user")!;
+  const { name } = c.req.valid("json");
+
+  logger.info({ userId: user.userId, projectName: name }, "Creating project");
+
+  try {
+    const project = await createProject(
+      {
+        projectsRepository: c.get("projectsRepository"),
+      },
+      name,
+      user.userId,
+    );
+
+    logger.info({ projectId: project.id }, "Project created successfully");
+
+    return c.json(
+      {
+        id: project.id,
+        name: project.name,
+        createdBy: project.createdBy,
+      },
+      201,
+    );
+  } catch (error) {
+    logger.error({ error }, "Failed to create project");
+    throw error;
+  }
+});
+
+export const projectsRoutes = app;

--- a/apps/hono-api/src/infrastructure/schemas/projects.ts
+++ b/apps/hono-api/src/infrastructure/schemas/projects.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+import { createRoute } from "@hono/zod-openapi";
+
+export const ProjectSchema = z.object({
+  id: z.string().openapi({ description: "プロジェクトID", example: "abc123" }),
+  name: z
+    .string()
+    .openapi({ description: "プロジェクト名", example: "新しいプロジェクト" }),
+  createdBy: z.string().openapi({ description: "作成者ID", example: "user123" }),
+});
+
+export const CreateProjectRequestSchema = z.object({
+  name: z
+    .string()
+    .min(1, "プロジェクト名は必須です")
+    .max(255, "プロジェクト名は255文字以下で入力してください")
+    .openapi({ description: "プロジェクト名", example: "新しいプロジェクト" }),
+});
+
+export const createProjectRoute = createRoute({
+  method: "post",
+  path: "/",
+  tags: ["Projects"],
+  summary: "新しいプロジェクトを作成",
+  description: "新しいプロジェクトを作成します。管理者権限が必要です。",
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: CreateProjectRequestSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    201: {
+      content: {
+        "application/json": {
+          schema: ProjectSchema,
+        },
+      },
+      description: "プロジェクトの作成に成功しました",
+    },
+    403: {
+      description: "管理者権限が必要です",
+    },
+  },
+});

--- a/apps/hono-api/src/infrastructure/schemas/projects.ts
+++ b/apps/hono-api/src/infrastructure/schemas/projects.ts
@@ -1,12 +1,14 @@
-import { z } from "zod";
 import { createRoute } from "@hono/zod-openapi";
+import { z } from "zod";
 
 export const ProjectSchema = z.object({
   id: z.string().openapi({ description: "プロジェクトID", example: "abc123" }),
   name: z
     .string()
     .openapi({ description: "プロジェクト名", example: "新しいプロジェクト" }),
-  createdBy: z.string().openapi({ description: "作成者ID", example: "user123" }),
+  createdBy: z
+    .string()
+    .openapi({ description: "作成者ID", example: "user123" }),
 });
 
 export const CreateProjectRequestSchema = z.object({

--- a/apps/hono-api/src/infrastructure/schemas/tasks.ts
+++ b/apps/hono-api/src/infrastructure/schemas/tasks.ts
@@ -1,5 +1,5 @@
-import { z } from "zod";
 import { createRoute } from "@hono/zod-openapi";
+import { z } from "zod";
 
 // Task schemas
 export const TaskSchema = z.object({

--- a/apps/hono-api/src/infrastructure/schemas/users.ts
+++ b/apps/hono-api/src/infrastructure/schemas/users.ts
@@ -1,5 +1,5 @@
-import { z } from "zod";
 import { createRoute } from "@hono/zod-openapi";
+import { z } from "zod";
 
 import { UserRoleConstants } from "../../domain/value/role.js";
 

--- a/apps/hono-api/src/infrastructure/server.ts
+++ b/apps/hono-api/src/infrastructure/server.ts
@@ -7,8 +7,10 @@ import type { Context } from "./context.js";
 import { env } from "./env.js";
 import { logger } from "./logger.js";
 import { traceIdMiddleware } from "./middleware/trace-id.js";
+import { ProjectsRepository } from "./repository/projects-repository.js";
 import { TasksRepository } from "./repository/tasks-repository.js";
 import { UsersRepository } from "./repository/users-repository.js";
+import { projectsRoutes } from "./routes/projects.js";
 import { tasksRoutes } from "./routes/tasks.js";
 import { usersRoutes } from "./routes/users.js";
 
@@ -34,6 +36,7 @@ app.use("*", async (c, next) => {
   c.set("logger", childLogger);
   c.set("tasksRepository", new TasksRepository());
   c.set("usersRepository", new UsersRepository());
+  c.set("projectsRepository", new ProjectsRepository());
 
   childLogger.info(
     {
@@ -60,6 +63,7 @@ app.use("*", async (c, next) => {
 
 app.route("/tasks", tasksRoutes);
 app.route("/users", usersRoutes);
+app.route("/projects", projectsRoutes);
 
 // OpenAPI documentation endpoints
 app.doc("/openapi.json", {


### PR DESCRIPTION
## 概要

管理者権限を持つユーザーがプロジェクトを作成できる機能を追加しました。

## 変更の種類

- [x] 新機能（既存機能を壊さない機能追加）
- [ ] バグ修正（既存機能を壊さない修正）
- [ ] 破壊的変更（既存機能に影響を与える修正や機能）
- [ ] リファクタリング（バグ修正や機能追加を伴わないコード変更）
- [ ] ドキュメント更新
- [ ] パフォーマンス改善
- [ ] テスト改善

## 変更内容

- [x] Projectドメインエンティティの作成
- [x] プロジェクトリポジトリインターフェースと実装の作成
- [x] データベーススキーマにprojectsとproject_membersテーブルを追加
- [x] プロジェクト作成APIエンドポイントの作成（POST /projects）
- [x] 管理者権限チェックミドルウェアの追加
- [x] プロジェクト作成時に作成者を自動でプロジェクトメンバーに追加

## 関連Issue

Closes #5

## 補足事項

- 管理者権限（role=2）を持つユーザーのみがプロジェクトを作成できます
- プロジェクト作成時に作成者が自動的にプロジェクトメンバーに追加されます
- Clean ArchitectureとDDDの原則に従って実装されています