### PR TITLE
feat: Claude Codeのコードレビューを日本語で返すように修正

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -17,14 +17,14 @@ jobs:
     #   github.event.pull_request.user.login == 'external-contributor' ||
     #   github.event.pull_request.user.login == 'new-developer' ||
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-    
+
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read
       issues: read
       id-token: write
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -36,21 +36,21 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          
+
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
           # model: "claude-opus-4-20250514"
-          
+
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |
-            Please review this pull request and provide feedback on:
-            - Code quality and best practices
-            - Potential bugs or issues
-            - Performance considerations
-            - Security concerns
-            - Test coverage
-            
-            Be constructive and helpful in your feedback.
-          
+            このプルリクエストをレビューして、以下の項目について日本語でフィードバックを提供してください：
+            - コード品質とベストプラクティス
+            - 潜在的なバグや問題
+            - パフォーマンスに関する考慮事項
+            - セキュリティ上の懸念
+            - テストカバレッジ
+
+            建設的で有用なフィードバックを心がけてください。
+
           # Optional: Customize review based on file types
           # direct_prompt: |
           #   Review this PR focusing on:
@@ -58,18 +58,17 @@ jobs:
           #   - For API endpoints: Security, input validation, and error handling
           #   - For React components: Performance, accessibility, and best practices
           #   - For tests: Coverage, edge cases, and test quality
-          
+
           # Optional: Different prompts for different authors
           # direct_prompt: |
-          #   ${{ github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' && 
+          #   ${{ github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' &&
           #   'Welcome! Please review this PR from a first-time contributor. Be encouraging and provide detailed explanations for any suggestions.' ||
           #   'Please provide a thorough code review focusing on our coding standards and best practices.' }}
-          
+
           # Optional: Add specific tools for running tests or linting
           # allowed_tools: "Bash(npm run test),Bash(npm run lint),Bash(npm run typecheck)"
-          
+
           # Optional: Skip review for certain conditions
           # if: |
           #   !contains(github.event.pull_request.title, '[skip-review]') &&
           #   !contains(github.event.pull_request.title, '[WIP]')
-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,26 +34,25 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          
+
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
           # model: "claude-opus-4-20250514"
-          
+
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"
-          
+
           # Optional: Trigger when specific user is assigned to an issue
           # assignee_trigger: "claude-bot"
-          
+
           # Optional: Allow Claude to run specific commands
           # allowed_tools: "Bash(npm install),Bash(npm run build),Bash(npm run test:*),Bash(npm run lint:*)"
-          
+
           # Optional: Add custom instructions for Claude to customize its behavior for your project
           # custom_instructions: |
           #   Follow our coding standards
           #   Ensure all new code has tests
           #   Use TypeScript for new files
-          
+
           # Optional: Custom environment variables for Claude
           # claude_env: |
           #   NODE_ENV: test
-

--- a/apps/hono-api/src/application/service/users.test.ts
+++ b/apps/hono-api/src/application/service/users.test.ts
@@ -184,7 +184,7 @@ describe("getUserSelf", () => {
 
     const result = await getUserSelf(
       { usersRepository: mockUsersRepository },
-      "user123"
+      "user123",
     );
 
     expect(result.success).toBe(true);
@@ -216,7 +216,7 @@ describe("getUserSelf", () => {
 
     const result = await getUserSelf(
       { usersRepository: mockUsersRepository },
-      "admin123"
+      "admin123",
     );
 
     expect(result.success).toBe(true);
@@ -241,7 +241,7 @@ describe("getUserSelf", () => {
 
     const result = await getUserSelf(
       { usersRepository: mockUsersRepository },
-      "non-existent-user-id"
+      "non-existent-user-id",
     );
 
     expect(result.success).toBe(false);
@@ -249,6 +249,8 @@ describe("getUserSelf", () => {
       expect(result.errors).toEqual(["User not found"]);
     }
 
-    expect(mockUsersRepository.findById).toHaveBeenCalledWith("non-existent-user-id");
+    expect(mockUsersRepository.findById).toHaveBeenCalledWith(
+      "non-existent-user-id",
+    );
   });
 });

--- a/apps/hono-api/src/application/service/users.ts
+++ b/apps/hono-api/src/application/service/users.ts
@@ -140,7 +140,7 @@ export const getUserSelf = async (
   userId: string,
 ): Promise<GetUserSelfResponse> => {
   const user = await deps.usersRepository.findById(userId);
-  
+
   if (!user) {
     return {
       success: false,

--- a/apps/hono-api/src/infrastructure/routes/projects.test.ts
+++ b/apps/hono-api/src/infrastructure/routes/projects.test.ts
@@ -63,7 +63,9 @@ describe("Projects Routes", () => {
       });
 
       expect(response.status).toBe(200);
-      const data = await response.json() as { pagination: { page: number; limit: number } };
+      const data = (await response.json()) as {
+        pagination: { page: number; limit: number };
+      };
       expect(data).toEqual({
         projects: mockProjects,
         pagination: {
@@ -101,7 +103,9 @@ describe("Projects Routes", () => {
       });
 
       expect(response.status).toBe(200);
-      const data = await response.json() as { pagination: { page: number; limit: number } };
+      const data = (await response.json()) as {
+        pagination: { page: number; limit: number };
+      };
       expect(data).toEqual({
         projects: mockProjects,
         pagination: {
@@ -132,7 +136,9 @@ describe("Projects Routes", () => {
       });
 
       expect(response.status).toBe(200);
-      const data = await response.json() as { pagination: { page: number; limit: number } };
+      const data = (await response.json()) as {
+        pagination: { page: number; limit: number };
+      };
       expect(data.pagination.page).toBe(1);
       expect(mockProjectsRepository.findByUserId).toHaveBeenCalledWith(
         "user1",
@@ -152,7 +158,9 @@ describe("Projects Routes", () => {
       });
 
       expect(response.status).toBe(200);
-      const data = await response.json() as { pagination: { page: number; limit: number } };
+      const data = (await response.json()) as {
+        pagination: { page: number; limit: number };
+      };
       expect(data.pagination.page).toBe(1);
       expect(mockProjectsRepository.findByUserId).toHaveBeenCalledWith(
         "user1",
@@ -172,7 +180,9 @@ describe("Projects Routes", () => {
       });
 
       expect(response.status).toBe(200);
-      const data = await response.json() as { pagination: { page: number; limit: number } };
+      const data = (await response.json()) as {
+        pagination: { page: number; limit: number };
+      };
       expect(data.pagination.limit).toBe(10);
       expect(mockProjectsRepository.findByUserId).toHaveBeenCalledWith(
         "user1",
@@ -192,7 +202,9 @@ describe("Projects Routes", () => {
       });
 
       expect(response.status).toBe(200);
-      const data = await response.json() as { pagination: { page: number; limit: number } };
+      const data = (await response.json()) as {
+        pagination: { page: number; limit: number };
+      };
       expect(data.pagination.limit).toBe(100);
       expect(mockProjectsRepository.findByUserId).toHaveBeenCalledWith(
         "user1",
@@ -212,7 +224,9 @@ describe("Projects Routes", () => {
       });
 
       expect(response.status).toBe(200);
-      const data = await response.json() as { pagination: { page: number; limit: number } };
+      const data = (await response.json()) as {
+        pagination: { page: number; limit: number };
+      };
       expect(data).toEqual({
         projects: [],
         pagination: {

--- a/apps/hono-api/src/infrastructure/routes/projects.ts
+++ b/apps/hono-api/src/infrastructure/routes/projects.ts
@@ -49,7 +49,7 @@ app.openapi(getProjectsRoute, async (c) => {
 app.openapi(createProjectRoute, async (c) => {
   const logger = c.get("logger");
   const user = c.get("user")!;
-  
+
   // 管理者権限をチェック
   if (!user || !UserRole.isAdminRole(user.role)) {
     logger.warn(

--- a/apps/hono-api/src/infrastructure/routes/users.test.ts
+++ b/apps/hono-api/src/infrastructure/routes/users.test.ts
@@ -228,8 +228,8 @@ describe("GET /users/self", () => {
     });
 
     expect(response.status).toBe(401);
-    
-    const body = await response.json() as { errors: string[] };
+
+    const body = (await response.json()) as { errors: string[] };
     expect(body.errors).toContain("Authentication required");
   });
 
@@ -240,7 +240,7 @@ describe("GET /users/self", () => {
       "テストユーザー",
       "test@example.com",
       "Password123!",
-      UserRole.member()
+      UserRole.member(),
     );
 
     const mockUsersRepository = {
@@ -272,7 +272,7 @@ describe("GET /users/self", () => {
 
       try {
         const userEntity = await usersRepository.findById(user.userId);
-        
+
         if (!userEntity) {
           logger.warn({ userId: user.userId }, "User not found");
           return c.json({ errors: ["User not found"] }, 401);
@@ -285,7 +285,10 @@ describe("GET /users/self", () => {
           role: userEntity.roleValue as "MEMBER" | "ADMIN",
         };
 
-        logger.info({ userId: user.userId }, "User self info retrieved successfully");
+        logger.info(
+          { userId: user.userId },
+          "User self info retrieved successfully",
+        );
         return c.json(userInfo, 200);
       } catch (error) {
         logger.error({ error }, "Failed to retrieve user self info");
@@ -298,7 +301,7 @@ describe("GET /users/self", () => {
     });
 
     expect(response.status).toBe(200);
-    
+
     const body = await response.json();
     expect(body).toEqual({
       id: user.id,
@@ -315,7 +318,7 @@ describe("GET /users/self", () => {
       "管理者",
       "admin@example.com",
       "Password123!",
-      UserRole.admin()
+      UserRole.admin(),
     );
 
     const mockUsersRepository = {
@@ -347,7 +350,7 @@ describe("GET /users/self", () => {
 
       try {
         const userEntity = await usersRepository.findById(user.userId);
-        
+
         if (!userEntity) {
           logger.warn({ userId: user.userId }, "User not found");
           return c.json({ errors: ["User not found"] }, 401);
@@ -360,7 +363,10 @@ describe("GET /users/self", () => {
           role: userEntity.roleValue as "MEMBER" | "ADMIN",
         };
 
-        logger.info({ userId: user.userId }, "User self info retrieved successfully");
+        logger.info(
+          { userId: user.userId },
+          "User self info retrieved successfully",
+        );
         return c.json(userInfo, 200);
       } catch (error) {
         logger.error({ error }, "Failed to retrieve user self info");
@@ -373,7 +379,7 @@ describe("GET /users/self", () => {
     });
 
     expect(response.status).toBe(200);
-    
+
     const body = await response.json();
     expect(body).toEqual({
       id: user.id,
@@ -415,7 +421,7 @@ describe("GET /users/self", () => {
 
       try {
         const userEntity = await usersRepository.findById(user.userId);
-        
+
         if (!userEntity) {
           logger.warn({ userId: user.userId }, "User not found");
           return c.json({ errors: ["User not found"] }, 401);
@@ -428,7 +434,10 @@ describe("GET /users/self", () => {
           role: userEntity.roleValue as "MEMBER" | "ADMIN",
         };
 
-        logger.info({ userId: user.userId }, "User self info retrieved successfully");
+        logger.info(
+          { userId: user.userId },
+          "User self info retrieved successfully",
+        );
         return c.json(userInfo, 200);
       } catch (error) {
         logger.error({ error }, "Failed to retrieve user self info");
@@ -441,8 +450,8 @@ describe("GET /users/self", () => {
     });
 
     expect(response.status).toBe(401);
-    
-    const body = await response.json() as { errors: string[] };
+
+    const body = (await response.json()) as { errors: string[] };
     expect(body.errors).toContain("User not found");
   });
 });

--- a/apps/hono-api/src/infrastructure/routes/users.ts
+++ b/apps/hono-api/src/infrastructure/routes/users.ts
@@ -1,7 +1,11 @@
 import { OpenAPIHono } from "@hono/zod-openapi";
 import { setCookie, deleteCookie } from "hono/cookie";
 
-import { registerUser, loginUser, getUserSelf } from "../../application/service/users.js";
+import {
+  registerUser,
+  loginUser,
+  getUserSelf,
+} from "../../application/service/users.js";
 import { authMiddleware } from "../auth/middleware.js";
 import type { Context } from "../context.js";
 import {
@@ -109,17 +113,26 @@ app.openapi(getUserSelfRoute, async (c) => {
     );
 
     if (!result.success) {
-      logger.warn({ userId: user.userId, errors: result.errors }, "Failed to retrieve user self info");
+      logger.warn(
+        { userId: user.userId, errors: result.errors },
+        "Failed to retrieve user self info",
+      );
       return c.json({ errors: result.errors }, 401);
     }
 
-    logger.info({ userId: user.userId }, "User self info retrieved successfully");
-    return c.json({
-      id: result.user.id,
-      name: result.user.name,
-      email: result.user.email,
-      role: result.user.role as "MEMBER" | "ADMIN",
-    }, 200);
+    logger.info(
+      { userId: user.userId },
+      "User self info retrieved successfully",
+    );
+    return c.json(
+      {
+        id: result.user.id,
+        name: result.user.name,
+        email: result.user.email,
+        role: result.user.role as "MEMBER" | "ADMIN",
+      },
+      200,
+    );
   } catch (error) {
     logger.error({ error }, "Failed to retrieve user self info");
     throw error;

--- a/apps/hono-api/src/infrastructure/schemas/projects.ts
+++ b/apps/hono-api/src/infrastructure/schemas/projects.ts
@@ -61,13 +61,13 @@ export const getProjectsRoute = createRoute({
         .number()
         .int()
         .default(1)
-        .transform(val => val <= 0 ? 1 : val)
+        .transform((val) => (val <= 0 ? 1 : val))
         .openapi({ description: "ページ番号", example: 1 }),
       limit: z.coerce
         .number()
         .int()
         .default(10)
-        .transform(val => val <= 0 ? 10 : val > 100 ? 100 : val)
+        .transform((val) => (val <= 0 ? 10 : val > 100 ? 100 : val))
         .openapi({ description: "1ページあたりの件数", example: 10 }),
     }),
   },

--- a/apps/hono-api/src/infrastructure/schemas/users.ts
+++ b/apps/hono-api/src/infrastructure/schemas/users.ts
@@ -172,9 +172,7 @@ export const logoutUserRoute = createRoute({
 
 export const GetUserSelfResponseSchema = z.object({
   id: z.string().openapi({ description: "ユーザーID", example: "abc123" }),
-  name: z
-    .string()
-    .openapi({ description: "ユーザー名", example: "田中太郎" }),
+  name: z.string().openapi({ description: "ユーザー名", example: "田中太郎" }),
   email: z.string().email().openapi({
     description: "メールアドレス",
     example: "tanaka@example.com",
@@ -210,7 +208,8 @@ export const getUserSelfRoute = createRoute({
           schema: GetUserSelfErrorResponseSchema,
         },
       },
-      description: "認証失敗（JWTトークンが無効またはユーザーが見つかりません）",
+      description:
+        "認証失敗（JWTトークンが無効またはユーザーが見つかりません）",
     },
   },
 });


### PR DESCRIPTION
## 概要

GitHub Actions workflowのプロンプトを日本語に変更し、Claude Codeによるコードレビューの結果を日本語で表示するように改善しました。

## 変更の種類

- [x] 新機能（既存機能を壊さない機能追加）
- [ ] バグ修正（既存機能を壊さない修正）
- [ ] 破壊的変更（既存機能に影響を与える修正や機能）
- [ ] リファクタリング（バグ修正や機能追加を伴わないコード変更）
- [ ] ドキュメント更新
- [ ] パフォーマンス改善
- [ ] テスト改善

## 変更内容

- [x] `.github/workflows/claude-code-review.yml` のプロンプトを日本語に変更
- [x] コードレビューの結果が日本語で表示されるように改善

## 関連Issue

Closes #32

## 補足事項

GitHub PR上でのClaude Codeによるコードレビューが日本語で表示されるようになり、日本語での開発体験が向上します。

🤖 Generated with [Claude Code](https://claude.ai/code)